### PR TITLE
[WIP]: Initial prototype

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
     defaults:
       run:
         shell: bash -l {0}

--- a/examples/example-item/example-item.json
+++ b/examples/example-item/example-item.json
@@ -3,9 +3,9 @@
   "stac_version": "1.0.0",
   "id": "20231010-short_range-conus-channel_rt-0-1",
   "properties": {
-    "nwm:category": "short_range",
-    "nwm:region": "conus",
-    "nwm:product": "channel_rt",
+    "nwm:model_configuration": "short_range",
+    "nwm:model_domain": "conus",
+    "nwm:file_output_type": "channel_rt",
     "nwm:forecast_hour": 1,
     "cube:dimensions": {
       "time": {

--- a/examples/example-item/example-item.json
+++ b/examples/example-item/example-item.json
@@ -1,87 +1,616 @@
 {
   "type": "Feature",
   "stac_version": "1.0.0",
-  "id": "example-item",
+  "id": "20231010-short_range-conus-channel_rt-0-1",
   "properties": {
-    "proj:epsg": 32621,
-    "proj:transform": [
-      100.01126757344893,
-      0.0,
-      373185.0,
-      0.0,
-      -100.01126757344893,
-      8286015.0
-    ],
-    "proj:shape": [
-      2667,
-      2658
-    ],
-    "custom_attribute": "foo",
-    "datetime": "2023-09-12T11:48:03.199913Z"
-  },
-  "geometry": {
-    "type": "Polygon",
-    "coordinates": [
-      [
-        [
-          -52.916275,
-          72.229798
+    "nwm:category": "short_range",
+    "nwm:region": "conus",
+    "nwm:product": "channel_rt",
+    "nwm:forecast_hour": 1,
+    "cube:dimensions": {
+      "time": {
+        "extent": [
+          "2023-10-10T01:00:00Z",
+          "2023-10-10T01:00:00Z"
         ],
-        [
-          -52.301599,
-          74.613784
+        "description": "valid output time",
+        "type": "temporal",
+        "kerchunk:zarray": {
+          "chunks": [
+            1024
+          ],
+          "compressor": {
+            "id": "zlib",
+            "level": 2
+          },
+          "dtype": "<i4",
+          "fill_value": null,
+          "filters": [
+            {
+              "elementsize": 4,
+              "id": "shuffle"
+            }
+          ],
+          "order": "C",
+          "shape": [
+            1
+          ],
+          "zarr_format": 2
+        },
+        "kerchunk:zattrs": {
+          "_ARRAY_DIMENSIONS": [
+            "time"
+          ],
+          "long_name": "valid output time",
+          "standard_name": "time",
+          "units": "minutes since 1970-01-01 00:00:00 UTC",
+          "valid_max": 28282680,
+          "valid_min": 28281660
+        },
+        "kerchunk:value": {
+          "0": "base64:eF7t0AEBAAAExEB6aSiMioL8rcFuSgQIpAps6rhvAgTqGBAgECvQsefGCRB40OEBeA=="
+        }
+      },
+      "feature_id": {
+        "type": "ID",
+        "description": "NHDPlusv2 ComIDs within CONUS, arbitrary Reach IDs outside of CONUS",
+        "extent": [
+          null,
+          null
         ],
-        [
-          -61.287624,
-          74.622043
+        "kerchunk:zarray": {
+          "chunks": [
+            2776734
+          ],
+          "compressor": {
+            "id": "zlib",
+            "level": 2
+          },
+          "dtype": "<i8",
+          "fill_value": null,
+          "filters": [
+            {
+              "elementsize": 8,
+              "id": "shuffle"
+            }
+          ],
+          "order": "C",
+          "shape": [
+            2776734
+          ],
+          "zarr_format": 2
+        },
+        "kerchunk:zattrs": {
+          "_ARRAY_DIMENSIONS": [
+            "feature_id"
+          ],
+          "cf_role": "timeseries_id",
+          "comment": "NHDPlusv2 ComIDs within CONUS, arbitrary Reach IDs outside of CONUS",
+          "long_name": "Reach ID"
+        },
+        "kerchunk:value": {
+          "0": [
+            "https://noaanwm.blob.core.windows.net/nwm/nwm.20231010/short_range/nwm.t00z.short_range.channel_rt.f001.conus.nc",
+            43319,
+            606659
+          ]
+        }
+      },
+      "reference_time": {
+        "type": "reference-time",
+        "description": "model initialization time",
+        "extent": [
+          null,
+          null
         ],
-        [
-          -60.726346,
-          72.236891
-        ],
-        [
-          -52.916275,
-          72.229798
-        ]
-      ]
-    ]
-  },
-  "links": [
-    {
-      "rel": "root",
-      "href": "../collection.json",
-      "type": "application/json",
-      "title": "Example collection"
+        "kerchunk:zarray": {
+          "chunks": [
+            1
+          ],
+          "compressor": {
+            "id": "zlib",
+            "level": 2
+          },
+          "dtype": "<i4",
+          "fill_value": null,
+          "filters": [
+            {
+              "elementsize": 4,
+              "id": "shuffle"
+            }
+          ],
+          "order": "C",
+          "shape": [
+            1
+          ],
+          "zarr_format": 2
+        },
+        "kerchunk:zattrs": {
+          "_ARRAY_DIMENSIONS": [
+            "reference_time"
+          ],
+          "long_name": "model initialization time",
+          "standard_name": "forecast_reference_time",
+          "units": "minutes since 1970-01-01 00:00:00 UTC"
+        },
+        "kerchunk:value": {
+          "0": "base64:eF5j6F7PCAADBAE8"
+        }
+      }
     },
-    {
-      "rel": "collection",
-      "href": "../collection.json",
-      "type": "application/json",
-      "title": "Example collection"
+    "cube:variables": {
+      "crs": {
+        "type": "data",
+        "description": "CRS definition",
+        "dimensions": [],
+        "attrs": {
+          "transform_name": "latitude longitude",
+          "grid_mapping_name": "latitude longitude",
+          "esri_pe_string": "GEOGCS[\"GCS_WGS_1984\",DATUM[\"D_WGS_1984\",SPHEROID[\"WGS_1984\",6378137.0,298.257223563]],PRIMEM[\"Greenwich\",0.0],UNIT[\"Degree\",0.0174532925199433]];-400 -400 1000000000;-100000 10000;-100000 10000;8.98315284119521E-09;0.001;0.001;IsHighPrecision",
+          "spatial_ref": "GEOGCS[\"GCS_WGS_1984\",DATUM[\"D_WGS_1984\",SPHEROID[\"WGS_1984\",6378137.0,298.257223563]],PRIMEM[\"Greenwich\",0.0],UNIT[\"Degree\",0.0174532925199433]];-400 -400 1000000000;-100000 10000;-100000 10000;8.98315284119521E-09;0.001;0.001;IsHighPrecision",
+          "long_name": "CRS definition",
+          "longitude_of_prime_meridian": 0.0,
+          "_CoordinateAxes": "latitude longitude",
+          "semi_major_axis": 6378137.0,
+          "semi_minor_axis": 6356752.5,
+          "inverse_flattening": 298.2572326660156
+        },
+        "shape": [],
+        "kerchunk:zarray": {
+          "chunks": [],
+          "compressor": null,
+          "dtype": "|S1",
+          "fill_value": "IA==",
+          "filters": null,
+          "order": "C",
+          "shape": [],
+          "zarr_format": 2
+        },
+        "kerchunk:zattrs": {
+          "_ARRAY_DIMENSIONS": [],
+          "_CoordinateAxes": "latitude longitude",
+          "esri_pe_string": "GEOGCS[\"GCS_WGS_1984\",DATUM[\"D_WGS_1984\",SPHEROID[\"WGS_1984\",6378137.0,298.257223563]],PRIMEM[\"Greenwich\",0.0],UNIT[\"Degree\",0.0174532925199433]];-400 -400 1000000000;-100000 10000;-100000 10000;8.98315284119521E-09;0.001;0.001;IsHighPrecision",
+          "grid_mapping_name": "latitude longitude",
+          "inverse_flattening": 298.2572326660156,
+          "long_name": "CRS definition",
+          "longitude_of_prime_meridian": 0.0,
+          "semi_major_axis": 6378137.0,
+          "semi_minor_axis": 6356752.5,
+          "spatial_ref": "GEOGCS[\"GCS_WGS_1984\",DATUM[\"D_WGS_1984\",SPHEROID[\"WGS_1984\",6378137.0,298.257223563]],PRIMEM[\"Greenwich\",0.0],UNIT[\"Degree\",0.0174532925199433]];-400 -400 1000000000;-100000 10000;-100000 10000;8.98315284119521E-09;0.001;0.001;IsHighPrecision",
+          "transform_name": "latitude longitude"
+        },
+        "kerchunk:value": {
+          "0": "\u0000"
+        }
+      },
+      "streamflow": {
+        "type": "data",
+        "description": "River Flow",
+        "dimensions": [
+          "feature_id"
+        ],
+        "unit": "m3 s-1",
+        "attrs": {
+          "long_name": "River Flow",
+          "units": "m3 s-1",
+          "grid_mapping": "crs",
+          "valid_range": [
+            0,
+            5000000
+          ]
+        },
+        "shape": [
+          2776734
+        ],
+        "kerchunk:zarray": {
+          "chunks": [
+            2776734
+          ],
+          "compressor": {
+            "id": "zlib",
+            "level": 2
+          },
+          "dtype": "<i4",
+          "fill_value": -999900,
+          "filters": [
+            {
+              "elementsize": 4,
+              "id": "shuffle"
+            }
+          ],
+          "order": "C",
+          "shape": [
+            2776734
+          ],
+          "zarr_format": 2
+        },
+        "kerchunk:zattrs": {
+          "_ARRAY_DIMENSIONS": [
+            "feature_id"
+          ],
+          "add_offset": 0.0,
+          "coordinates": "latitude longitude",
+          "grid_mapping": "crs",
+          "long_name": "River Flow",
+          "missing_value": -999900,
+          "scale_factor": 0.009999999776482582,
+          "units": "m3 s-1",
+          "valid_range": [
+            0,
+            5000000
+          ]
+        },
+        "kerchunk:value": {
+          "0": [
+            "https://noaanwm.blob.core.windows.net/nwm/nwm.20231010/short_range/nwm.t00z.short_range.channel_rt.f001.conus.nc",
+            662554,
+            1725436
+          ]
+        }
+      },
+      "nudge": {
+        "type": "data",
+        "description": "Amount of stream flow alteration",
+        "dimensions": [
+          "feature_id"
+        ],
+        "unit": "m3 s-1",
+        "attrs": {
+          "long_name": "Amount of stream flow alteration",
+          "units": "m3 s-1",
+          "grid_mapping": "crs",
+          "valid_range": [
+            -5000000,
+            5000000
+          ]
+        },
+        "shape": [
+          2776734
+        ],
+        "kerchunk:zarray": {
+          "chunks": [
+            2776734
+          ],
+          "compressor": {
+            "id": "zlib",
+            "level": 2
+          },
+          "dtype": "<i4",
+          "fill_value": -999900,
+          "filters": [
+            {
+              "elementsize": 4,
+              "id": "shuffle"
+            }
+          ],
+          "order": "C",
+          "shape": [
+            2776734
+          ],
+          "zarr_format": 2
+        },
+        "kerchunk:zattrs": {
+          "_ARRAY_DIMENSIONS": [
+            "feature_id"
+          ],
+          "add_offset": 0.0,
+          "coordinates": "latitude longitude",
+          "grid_mapping": "crs",
+          "long_name": "Amount of stream flow alteration",
+          "missing_value": -999900,
+          "scale_factor": 0.009999999776482582,
+          "units": "m3 s-1",
+          "valid_range": [
+            -5000000,
+            5000000
+          ]
+        },
+        "kerchunk:value": {
+          "0": [
+            "https://noaanwm.blob.core.windows.net/nwm/nwm.20231010/short_range/nwm.t00z.short_range.channel_rt.f001.conus.nc",
+            2387990,
+            110714
+          ]
+        }
+      },
+      "velocity": {
+        "type": "data",
+        "description": "River Velocity",
+        "dimensions": [
+          "feature_id"
+        ],
+        "unit": "m s-1",
+        "attrs": {
+          "long_name": "River Velocity",
+          "units": "m s-1",
+          "grid_mapping": "crs",
+          "valid_range": [
+            0,
+            5000000
+          ]
+        },
+        "shape": [
+          2776734
+        ],
+        "kerchunk:zarray": {
+          "chunks": [
+            2776734
+          ],
+          "compressor": {
+            "id": "zlib",
+            "level": 2
+          },
+          "dtype": "<i4",
+          "fill_value": -999900,
+          "filters": [
+            {
+              "elementsize": 4,
+              "id": "shuffle"
+            }
+          ],
+          "order": "C",
+          "shape": [
+            2776734
+          ],
+          "zarr_format": 2
+        },
+        "kerchunk:zattrs": {
+          "_ARRAY_DIMENSIONS": [
+            "feature_id"
+          ],
+          "add_offset": 0.0,
+          "coordinates": "latitude longitude",
+          "grid_mapping": "crs",
+          "long_name": "River Velocity",
+          "missing_value": -999900,
+          "scale_factor": 0.009999999776482582,
+          "units": "m s-1",
+          "valid_range": [
+            0,
+            5000000
+          ]
+        },
+        "kerchunk:value": {
+          "0": [
+            "https://noaanwm.blob.core.windows.net/nwm/nwm.20231010/short_range/nwm.t00z.short_range.channel_rt.f001.conus.nc",
+            2498704,
+            2024055
+          ]
+        }
+      },
+      "qSfcLatRunoff": {
+        "type": "data",
+        "description": "Runoff from terrain routing",
+        "dimensions": [
+          "feature_id"
+        ],
+        "unit": "m3 s-1",
+        "attrs": {
+          "long_name": "Runoff from terrain routing",
+          "units": "m3 s-1",
+          "grid_mapping": "crs",
+          "valid_range": [
+            0,
+            2000000000
+          ]
+        },
+        "shape": [
+          2776734
+        ],
+        "kerchunk:zarray": {
+          "chunks": [
+            2776734
+          ],
+          "compressor": {
+            "id": "zlib",
+            "level": 2
+          },
+          "dtype": "<i4",
+          "fill_value": -999900000,
+          "filters": [
+            {
+              "elementsize": 4,
+              "id": "shuffle"
+            }
+          ],
+          "order": "C",
+          "shape": [
+            2776734
+          ],
+          "zarr_format": 2
+        },
+        "kerchunk:zattrs": {
+          "_ARRAY_DIMENSIONS": [
+            "feature_id"
+          ],
+          "add_offset": 0.0,
+          "coordinates": "latitude longitude",
+          "grid_mapping": "crs",
+          "long_name": "Runoff from terrain routing",
+          "missing_value": -999900000,
+          "scale_factor": 9.999999747378752e-06,
+          "units": "m3 s-1",
+          "valid_range": [
+            0,
+            2000000000
+          ]
+        },
+        "kerchunk:value": {
+          "0": [
+            "https://noaanwm.blob.core.windows.net/nwm/nwm.20231010/short_range/nwm.t00z.short_range.channel_rt.f001.conus.nc",
+            4522759,
+            305804
+          ]
+        }
+      },
+      "qBucket": {
+        "type": "data",
+        "description": "Flux from gw bucket",
+        "dimensions": [
+          "feature_id"
+        ],
+        "unit": "m3 s-1",
+        "attrs": {
+          "long_name": "Flux from gw bucket",
+          "units": "m3 s-1",
+          "grid_mapping": "crs",
+          "valid_range": [
+            0,
+            2000000000
+          ]
+        },
+        "shape": [
+          2776734
+        ],
+        "kerchunk:zarray": {
+          "chunks": [
+            2776734
+          ],
+          "compressor": {
+            "id": "zlib",
+            "level": 2
+          },
+          "dtype": "<i4",
+          "fill_value": -999900000,
+          "filters": [
+            {
+              "elementsize": 4,
+              "id": "shuffle"
+            }
+          ],
+          "order": "C",
+          "shape": [
+            2776734
+          ],
+          "zarr_format": 2
+        },
+        "kerchunk:zattrs": {
+          "_ARRAY_DIMENSIONS": [
+            "feature_id"
+          ],
+          "add_offset": 0.0,
+          "coordinates": "latitude longitude",
+          "grid_mapping": "crs",
+          "long_name": "Flux from gw bucket",
+          "missing_value": -999900000,
+          "scale_factor": 9.999999747378752e-06,
+          "units": "m3 s-1",
+          "valid_range": [
+            0,
+            2000000000
+          ]
+        },
+        "kerchunk:value": {
+          "0": [
+            "https://noaanwm.blob.core.windows.net/nwm/nwm.20231010/short_range/nwm.t00z.short_range.channel_rt.f001.conus.nc",
+            4828563,
+            3302866
+          ]
+        }
+      },
+      "qBtmVertRunoff": {
+        "type": "data",
+        "description": "Runoff from bottom of soil to bucket",
+        "dimensions": [
+          "feature_id"
+        ],
+        "unit": "m3",
+        "attrs": {
+          "long_name": "Runoff from bottom of soil to bucket",
+          "units": "m3",
+          "grid_mapping": "crs",
+          "valid_range": [
+            0,
+            20000000
+          ]
+        },
+        "shape": [
+          2776734
+        ],
+        "kerchunk:zarray": {
+          "chunks": [
+            2776734
+          ],
+          "compressor": {
+            "id": "zlib",
+            "level": 2
+          },
+          "dtype": "<i4",
+          "fill_value": -9999000,
+          "filters": [
+            {
+              "elementsize": 4,
+              "id": "shuffle"
+            }
+          ],
+          "order": "C",
+          "shape": [
+            2776734
+          ],
+          "zarr_format": 2
+        },
+        "kerchunk:zattrs": {
+          "_ARRAY_DIMENSIONS": [
+            "feature_id"
+          ],
+          "add_offset": 0.0,
+          "coordinates": "latitude longitude",
+          "grid_mapping": "crs",
+          "long_name": "Runoff from bottom of soil to bucket",
+          "missing_value": -9999000,
+          "scale_factor": 0.0010000000474974513,
+          "units": "m3",
+          "valid_range": [
+            0,
+            20000000
+          ]
+        },
+        "kerchunk:value": {
+          "0": [
+            "https://noaanwm.blob.core.windows.net/nwm/nwm.20231010/short_range/nwm.t00z.short_range.channel_rt.f001.conus.nc",
+            8131429,
+            4568313
+          ]
+        }
+      }
     },
-    {
-      "rel": "parent",
-      "href": "../collection.json",
-      "type": "application/json",
-      "title": "Example collection"
-    }
-  ],
+    "start_datetime": "2023-10-10T01:00:00Z",
+    "end_datetime": "2023-10-10T01:00:00Z",
+    "kerchunk:zgroup": {
+      "zarr_format": 2
+    },
+    "kerchunk:zattrs": {
+      "Conventions": "CF-1.6",
+      "NWM_version_number": "v3.0",
+      "TITLE": "OUTPUT FROM NWM v3.0",
+      "cdm_datatype": "Station",
+      "code_version": "v5.3.0-alpha1",
+      "dev": "dev_ prefix indicates development/internal meta data",
+      "dev_NOAH_TIMESTEP": 3600,
+      "dev_OVRTSWCRT": 1,
+      "dev_channelBucket_only": 0,
+      "dev_channel_only": 0,
+      "featureType": "timeSeries",
+      "model_configuration": "short_range",
+      "model_initialization_time": "2023-10-10_00:00:00",
+      "model_output_type": "channel_rt",
+      "model_output_valid_time": "2023-10-10_01:00:00",
+      "model_total_valid_times": 18,
+      "proj4": "+proj=lcc +units=m +a=6370000.0 +b=6370000.0 +lat_1=30.0 +lat_2=60.0 +lat_0=40.0 +lon_0=-97.0 +x_0=0 +y_0=0 +k_0=1.0 +nadgrids=@",
+      "station_dimension": "feature_id",
+      "stream_order_output": 1
+    },
+    "datetime": "2023-10-10T01:00:00Z"
+  },
+  "geometry": null,
+  "links": [],
   "assets": {
     "data": {
-      "href": "../../tests/data/asset.tif",
-      "roles": [
-        "data"
-      ]
+      "href": "https://noaanwm.blob.core.windows.net/nwm/nwm.20231010/short_range/nwm.t00z.short_range.channel_rt.f001.conus.nc",
+      "type": "application/x-netcdf"
     }
   },
-  "bbox": [
-    -61.287624,
-    72.229798,
-    -52.301599,
-    74.622043
-  ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
-  ],
-  "collection": "example-collection"
+    "https://stac-extensions.github.io/datacube/v2.0.0/schema.json"
+  ]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 requires-python = ">=3.8"
-dependencies = ["stactools>=0.4.0"]
+dependencies = ["stactools>=0.4.0", "xstac>=1.2.0", "fsspec[http]"]
 
 [project.optional-dependencies]
 dev = [

--- a/scripts/update-examples
+++ b/scripts/update-examples
@@ -1,21 +1,33 @@
 #!/usr/bin/env python
-
-import shutil
+import json
 from pathlib import Path
+from stactools.noaa_nwm import stac
+import kerchunk.hdf
 
-import stactools.noaa_nwm.stac
-from pystac import CatalogType
+href = "https://noaanwm.blob.core.windows.net/nwm/nwm.20231010/short_range/nwm.t00z.short_range.channel_rt.f001.conus.nc"
+indices = kerchunk.hdf.SingleHdf5ToZarr(href).translate()
+item = stac.create_item(href, kerchunk_indices=indices)
 
-root = Path(__file__).parents[1]
-examples = root / "examples"
+with open("examples/example-item/example-item.json", "w") as f:
+    json.dump(item.to_dict(), f, indent=2)
 
-collection = stactools.noaa_nwm.stac.create_collection()
-item = stactools.noaa_nwm.stac.create_item(str(root / "tests" / "data" / "asset.tif"))
-collection.add_item(item)
-collection.update_extent_from_items()
-collection.normalize_hrefs(str(examples))
-collection.make_all_asset_hrefs_relative()
-if examples.exists():
-    shutil.rmtree(examples)
-    examples.mkdir()
-collection.save(CatalogType.SELF_CONTAINED)
+
+
+# import shutil
+
+# import stactools.noaa_nwm.stac
+# from pystac import CatalogType
+
+# root = Path(__file__).parents[1]
+# examples = root / "examples"
+
+# collection = stactools.noaa_nwm.stac.create_collection()
+# item = stactools.noaa_nwm.stac.create_item(str(root / "tests" / "data" / "asset.tif"))
+# collection.add_item(item)
+# collection.update_extent_from_items()
+# collection.normalize_hrefs(str(examples))
+# collection.make_all_asset_hrefs_relative()
+# if examples.exists():
+#     shutil.rmtree(examples)
+#     examples.mkdir()
+# collection.save(CatalogType.SELF_CONTAINED)

--- a/scripts/update-examples
+++ b/scripts/update-examples
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 import json
-from pathlib import Path
-from stactools.noaa_nwm import stac
+
 import kerchunk.hdf
+from stactools.noaa_nwm import stac
 
 href = "https://noaanwm.blob.core.windows.net/nwm/nwm.20231010/short_range/nwm.t00z.short_range.channel_rt.f001.conus.nc"
 indices = kerchunk.hdf.SingleHdf5ToZarr(href).translate()
@@ -10,7 +10,6 @@ item = stac.create_item(href, kerchunk_indices=indices)
 
 with open("examples/example-item/example-item.json", "w") as f:
     json.dump(item.to_dict(), f, indent=2)
-
 
 
 # import shutil

--- a/src/stactools/noaa_nwm/commands.py
+++ b/src/stactools/noaa_nwm/commands.py
@@ -28,7 +28,7 @@ def create_noaanwm_command(cli: Group) -> Command:
         Args:
             destination: An HREF for the Collection JSON
         """
-        collection = stac.create_collection()
+        collection = stac.create_collection()  # type: ignore
         collection.set_self_href(destination)
         collection.save_object()
 

--- a/src/stactools/noaa_nwm/stac.py
+++ b/src/stactools/noaa_nwm/stac.py
@@ -54,7 +54,7 @@ class NWMInfo:
     )
 
     @classmethod
-    def from_filename(cls, s: str):
+    def from_filename(cls, s: str) -> "NWMInfo":
         m = cls.pattern.match(s)
         assert m
         d = m.groupdict()
@@ -75,13 +75,13 @@ class NWMInfo:
             product=product,
         )
 
-    @property
-    def filename(self):
-        # reconstruct it
-        ...
+    # @property
+    # def filename(self) -> str:
+    #     # reconstruct it
+    #     ...
 
     @property
-    def id(self):
+    def id(self) -> str:
         return "-".join(
             [
                 self.date.strftime("%Y%m%d"),
@@ -94,12 +94,12 @@ class NWMInfo:
         )
 
     @property
-    def datetime(self):
+    def datetime(self) -> datetime.datetime:
         # TODO: confirm this is correct
         return self.date + datetime.timedelta(hours=self.forecast_hour)
 
     @property
-    def extra_properties(self):
+    def extra_properties(self) -> dict[str, str | int]:
         # TODO: use the forecast extension
         return {
             "nwm:category": self.category.value,
@@ -111,9 +111,9 @@ class NWMInfo:
 
 def create_item(
     href: str,
-    read_href_modifier=None,
+    read_href_modifier: typing.Callable[[str], str] | None = None,
     kerchunk_indices: dict[str, typing.Any] | None = None,
-):
+) -> pystac.Item:
     path = "/".join(href.rsplit("/", 3)[-3:])
     info = NWMInfo.from_filename(path)
 
@@ -151,10 +151,11 @@ def create_item(
         **additional_dimensions,
     )
 
+    assert isinstance(item, pystac.Item)
     item.assets["data"] = pystac.Asset(href=href, media_type="application/x-netcdf")
 
     return item
 
 
-def create_collection():
-    ...
+def create_collection() -> pystac.Collection:
+    return pystac.Collection()

--- a/src/stactools/noaa_nwm/stac.py
+++ b/src/stactools/noaa_nwm/stac.py
@@ -157,5 +157,5 @@ def create_item(
     return item
 
 
-def create_collection() -> pystac.Collection:
-    return pystac.Collection()
+def create_collection():  # type: ignore
+    ...

--- a/src/stactools/noaa_nwm/stac.py
+++ b/src/stactools/noaa_nwm/stac.py
@@ -1,67 +1,159 @@
-from datetime import datetime, timezone
+import pystac
+import re
+import typing
+import dataclasses
+import datetime
+import enum
+import fsspec
+import xarray as xr
+import xstac
 
-import stactools.core.create
-from pystac import (
-    Collection,
-    Extent,
-    Item,
-    SpatialExtent,
-    TemporalExtent,
-)
+
+class Product(str, enum.Enum):
+    CHANNEL_RT = "channel_rt"
+    LAND = "land"
+    RESERVOIR = "reservoir"
+    TERRAIN_RT = "terrain_rt"
 
 
-def create_collection() -> Collection:
-    """Creates a STAC Collection.
+class Region(str, enum.Enum):
+    CONUS = "conus"
 
-    This function should create a collection for this dataset. See `the STAC
-    specification
-    <https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection-spec.md>`_
-    for information about collection fields, and
-    `Collection<https://pystac.readthedocs.io/en/latest/api.html#collection>`_
-    for information about the PySTAC class.
 
-    Returns:
-        Collection: STAC Collection object
+class Category(str, enum.Enum):
+    SHORT_RANGE = "short_range"
+
+
+@dataclasses.dataclass
+class NWMInfo:
     """
-    extent = Extent(
-        SpatialExtent([[-180.0, 90.0, 180.0, -90.0]]),
-        TemporalExtent([[datetime.now(tz=timezone.utc), None]]),
+    Examples
+    --------
+    >>> info = NWMInfo.from_filename(
+    ...     "nwm.20231010/short_range/nwm.t00z.short_range.channel_rt.f001.conus.nc"
+    ... )
+    >>> info
+    """
+
+    date: datetime.datetime
+    category: Category  # literal / enum
+    cycle_runtime: int  # literal / enum
+    product: Product
+    forecast_hour: int
+    region: Region
+
+    pattern = re.compile(
+        "nwm\.(?P<date>\d{8})/"
+        "(?P<category>short_range)"
+        "/nwm\.t(?P<cycle_runtime>"
+        "\d{2})z\.short_range\."
+        "(?P<product>(channel_rt|land|reservoir|terrain_rt))\."
+        "f(?P<forecast_hour>\d{3})\."
+        "(?P<region>conus)\.nc"
     )
 
-    collection = Collection(
-        id="example-collection",
-        title="Example collection",
-        description="An example collection",
-        extent=extent,
-        extra_fields={"custom_attribute": "foo"},
+    @classmethod
+    def from_filename(cls, s: str):
+        m = cls.pattern.match(s)
+        assert m
+        d = m.groupdict()
+
+        date = datetime.datetime.strptime(d["date"], "%Y%m%d")
+        category = Category(d["category"])
+        cycle_runtime = int(d["cycle_runtime"])
+        forecast_hour = int(d["forecast_hour"])
+        region = Region(d["region"])
+        product = Product(d["product"])
+
+        return cls(
+            date=date,
+            category=category,
+            cycle_runtime=cycle_runtime,
+            forecast_hour=forecast_hour,
+            region=region,
+            product=product,
+        )
+
+    @property
+    def filename(self):
+        # reconstruct it
+        ...
+
+    @property
+    def id(self):
+        return "-".join(
+            [
+                self.date.strftime("%Y%m%d"),
+                self.category,
+                self.region,
+                self.product,
+                str(self.cycle_runtime),
+                str(self.forecast_hour),
+            ]
+        )
+
+    @property
+    def datetime(self):
+        # TODO: confirm this is correct
+        return self.date + datetime.timedelta(hours=self.forecast_hour)
+
+    @property
+    def extra_properties(self):
+        # TODO: use the forecast extension
+        return {
+            "nwm:category": self.category.value,
+            "nwm:region": self.region.value,
+            "nwm:product": self.product.value,
+            "nwm:forecast_hour": self.forecast_hour,
+        }
+
+
+def create_item(
+    href: str,
+    read_href_modifier=None,
+    kerchunk_indices: dict[str, typing.Any] | None = None,
+):
+    path = "/".join(href.rsplit("/", 3)[-3:])
+    info = NWMInfo.from_filename(path)
+
+    ds = xr.open_dataset(fsspec.open(href).open())
+    ds = xstac.fix_attrs(ds)
+
+    # TODO: geometry from the region (conus, ...)
+    template = pystac.Item(
+        info.id,
+        geometry=None,
+        bbox=None,
+        datetime=info.datetime,
+        properties=dict(info.extra_properties),
     )
-    return collection
 
+    additional_dimensions = {
+        "feature_id": {
+            "type": "ID",
+            "description": ds.feature_id.attrs["comment"],
+            "extent": [None, None],
+        },
+        "reference_time": {
+            "type": "reference-time",
+            "description": ds.reference_time.attrs["long_name"],
+            "extent": [None, None],
+        },
+    }
 
-def create_item(asset_href: str) -> Item:
-    """Creates a STAC item from a raster asset.
+    item = xstac.xarray_to_stac(
+        ds,
+        template,
+        x_dimension=False,
+        y_dimension=False,
+        kerchunk_indices=kerchunk_indices,
+        **additional_dimensions,
+    )
 
-    This example function uses :py:func:`stactools.core.utils.create_item` to
-    generate an example item.  Datasets should customize the item with
-    dataset-specific information, e.g.  extracted from metadata files.
+    item.assets["data"] = pystac.Asset(href=href, media_type="application/x-netcdf")
 
-    See `the STAC specification
-    <https://github.com/radiantearth/stac-spec/blob/master/item-spec/item-spec.md>`_
-    for information about an item's fields, and
-    `Item<https://pystac.readthedocs.io/en/latest/api/pystac.html#pystac.Item>`_ for
-    information on the PySTAC class.
-
-    This function should be updated to take all hrefs needed to build the item.
-    It is an anti-pattern to assume that related files (e.g. metadata) are in
-    the same directory as the primary file.
-
-    Args:
-        asset_href (str): The HREF pointing to an asset associated with the item
-
-    Returns:
-        Item: STAC Item object
-    """
-    item = stactools.core.create.item(asset_href)
-    item.id = "example-item"
-    item.properties["custom_attribute"] = "foo"
     return item
+
+
+def create_collection():
+    ...

--- a/src/stactools/noaa_nwm/stac.py
+++ b/src/stactools/noaa_nwm/stac.py
@@ -1,10 +1,11 @@
-import pystac
-import re
-import typing
 import dataclasses
 import datetime
 import enum
+import re
+import typing
+
 import fsspec
+import pystac
 import xarray as xr
 import xstac
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,36 +1,36 @@
-from pathlib import Path
+#from pathlib import Path
 
-from click import Group
-from click.testing import CliRunner
-from pystac import Collection, Item
-from stactools.noaa_nwm.commands import create_noaanwm_command
+#from click import Group
+#from click.testing import CliRunner
+#from pystac import Collection, Item
+#from stactools.noaa_nwm.commands import create_noaanwm_command
 
-from . import test_data
+#from . import test_data
 
-command = create_noaanwm_command(Group())
-
-
-def test_create_collection(tmp_path: Path) -> None:
-    # Smoke test for the command line create-collection command
-    #
-    # Most checks should be done in test_stac.py::test_create_collection
-
-    path = str(tmp_path / "collection.json")
-    runner = CliRunner()
-    result = runner.invoke(command, ["create-collection", path])
-    assert result.exit_code == 0, "\n{}".format(result.output)
-    collection = Collection.from_file(path)
-    collection.validate()
+#command = create_noaanwm_command(Group())
 
 
-def test_create_item(tmp_path: Path) -> None:
-    # Smoke test for the command line create-item command
-    #
-    # Most checks should be done in test_stac.py::test_create_item
-    asset_href = test_data.get_path("data/asset.tif")
-    path = str(tmp_path / "item.json")
-    runner = CliRunner()
-    result = runner.invoke(command, ["create-item", asset_href, path])
-    assert result.exit_code == 0, "\n{}".format(result.output)
-    item = Item.from_file(path)
-    item.validate()
+#def test_create_collection(tmp_path: Path) -> None:
+#    # Smoke test for the command line create-collection command
+#    #
+#    # Most checks should be done in test_stac.py::test_create_collection
+
+#    path = str(tmp_path / "collection.json")
+#    runner = CliRunner()
+#    result = runner.invoke(command, ["create-collection", path])
+#    assert result.exit_code == 0, "\n{}".format(result.output)
+#    collection = Collection.from_file(path)
+#    collection.validate()
+
+
+#def test_create_item(tmp_path: Path) -> None:
+#    # Smoke test for the command line create-item command
+#    #
+#    # Most checks should be done in test_stac.py::test_create_item
+#    asset_href = test_data.get_path("data/asset.tif")
+#    path = str(tmp_path / "item.json")
+#    runner = CliRunner()
+#    result = runner.invoke(command, ["create-item", asset_href, path])
+#    assert result.exit_code == 0, "\n{}".format(result.output)
+#    item = Item.from_file(path)
+#    item.validate()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,16 +1,16 @@
-#from pathlib import Path
+# from pathlib import Path
 
-#from click import Group
-#from click.testing import CliRunner
-#from pystac import Collection, Item
-#from stactools.noaa_nwm.commands import create_noaanwm_command
+# from click import Group
+# from click.testing import CliRunner
+# from pystac import Collection, Item
+# from stactools.noaa_nwm.commands import create_noaanwm_command
 
-#from . import test_data
+# from . import test_data
 
-#command = create_noaanwm_command(Group())
+# command = create_noaanwm_command(Group())
 
 
-#def test_create_collection(tmp_path: Path) -> None:
+# def test_create_collection(tmp_path: Path) -> None:
 #    # Smoke test for the command line create-collection command
 #    #
 #    # Most checks should be done in test_stac.py::test_create_collection
@@ -23,7 +23,7 @@
 #    collection.validate()
 
 
-#def test_create_item(tmp_path: Path) -> None:
+# def test_create_item(tmp_path: Path) -> None:
 #    # Smoke test for the command line create-item command
 #    #
 #    # Most checks should be done in test_stac.py::test_create_item

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -7,7 +7,7 @@ def test_create_collection() -> None:
     # This function should be updated to exercise the attributes of interest on
     # the collection
 
-    collection = stac.create_collection()
+    collection = stac.create_collection()  # type: ignore
     collection.set_self_href(None)  # required for validation to pass
     assert collection.id == "example-collection"
     assert collection.extra_fields["custom_attribute"] == "foo"

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -1,24 +1,23 @@
-from stactools.noaa_nwm import stac
+# from stactools.noaa_nwm import stac
 
-from . import test_data
+# from . import test_data
+
+# def test_create_collection() -> None:
+#     # This function should be updated to exercise the attributes of interest on
+#     # the collection
+
+#     collection = stac.create_collection()  # type: ignore
+#     collection.set_self_href(None)  # required for validation to pass
+#     assert collection.id == "example-collection"
+#     assert collection.extra_fields["custom_attribute"] == "foo"
+#     collection.validate()
 
 
-def test_create_collection() -> None:
-    # This function should be updated to exercise the attributes of interest on
-    # the collection
+# def test_create_item() -> None:
+#     # This function should be updated to exercise the attributes of interest on
+#     # a typical item
 
-    collection = stac.create_collection()  # type: ignore
-    collection.set_self_href(None)  # required for validation to pass
-    assert collection.id == "example-collection"
-    assert collection.extra_fields["custom_attribute"] == "foo"
-    collection.validate()
-
-
-def test_create_item() -> None:
-    # This function should be updated to exercise the attributes of interest on
-    # a typical item
-
-    item = stac.create_item(test_data.get_path("data/asset.tif"))
-    assert item.id == "example-item"
-    assert item.properties["custom_attribute"] == "foo"
-    item.validate()
+#     item = stac.create_item(test_data.get_path("data/asset.tif"))
+#     assert item.id == "example-item"
+#     assert item.properties["custom_attribute"] == "foo"
+#     item.validate()


### PR DESCRIPTION
This is a prototype of what a stactools package like this might look like.

At a high level, it would make one STAC item per NetCDF file distributed by NODD. For example, "https://noaanwm.blob.core.windows.net/nwm/nwm.20231010/short_range/nwm.t00z.short_range.channel_rt.f001.conus.nc".

It relies on that naming convention to derive some STAC properties, using the parts after `/nwm/`, i.e. `nwm.20231010/short_range/nwm.t00z.short_range.channel_rt.f001.conus.nc`.



I've optionally used a new feature of `xstac` to embed Kerchunk references in the STAC metadata. See examples/example-item/example-item.json for an example.

Some open questions:


1. I've invented some names for "product" (channel_rt, land, etc.), "Region" (consus, alaska, etc), "Category" ("short_range", "long_range", etc.), "cycle runtime". These probably have proper names given by NOAA. We should use those.
2. What's the appropriate `bbox` and `geometry` to use for the `channel_rt` data? We can't get it just from the NetCDF data. We'd need to get the `reaches` file. It should be the same for every item (by region: conus, alaska, etc.).
3. We should use the [forecast](https://github.com/stac-extensions/forecast) extension to catalog the `reference_datetime`, `horizon`, etc.
4. I've assumed that we'd have one STAC Catalog per "category - product" pair. But I haven't implemented that, and we could be flexible with how this is modeled.
